### PR TITLE
Fixed the version on the expressjs dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/neumino/chateau/issues"
   },
   "dependencies": {
-    "express": ">= 3.3.4",
+    "express": "3.3.4",
     "jade": ">= 1.0.0",
     "rethinkdb": ">= 1.8.0-0",
     "optimist": " >= 0.6.0",


### PR DESCRIPTION
It was >=3.3.4 and around 4.x they introduced some (breaking) API changes I guess, because I was getting the pasted stack trace on startup.

Making the version constraint '3.3.4' fixes the problem. 

/Users/pmetz/projects/chateau/app.js:18
            throw err;
                  ^
TypeError: Object function (req, res, next) {
    app.handle(req, res, next);
  } has no method 'configure'
    at module.exports (/Users/pmetz/projects/chateau/app.js:24:9)
    at Object.<anonymous> (/Users/pmetz/projects/chateau/bin/chateau:18:31)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
