### PR TITLE
Connect with user/password & ssl

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -1,7 +1,10 @@
 // RethinkDB settings
 exports.host = 'localhost';    // RethinkDB host
 exports.port = 28015;          // RethinkDB driver port
-exports.authKey = '';          // Authentification key (leave an empty string if you did not set one)
+exports.authKey = undefined;   // RethinkDB authentification key (optional)
+exports.user = undefined       // RethinkDB user name (optional)
+exports.password = undefined   // RethinkDB user password (optional)
+exports.ssl = undefined        // RethinkDB SSL certificate config (optional)
 
 // Express settings
 exports.expressPort = 3000;    // Port used by express

--- a/routes/api.js
+++ b/routes/api.js
@@ -12,7 +12,10 @@ module.exports = function(config) {
         r.connect({
             host: config.host,
             port: config.port,
-            authKey: config.authKey
+            authKey: config.authKey,
+            user: config.user,
+            password: config.password,
+            ssl: config.ssl
         }, function(error, conn) {
             // Throws, if we don't have a connection, we won't do anything...
             if (error) throw error


### PR DESCRIPTION
Fixes #53.

This lets the user connect to a db with a username/password, and ssl settings. This is the default connection settings for [Compose's hosted RethinkDBs](https://www.compose.com/rethinkdb).

- [x] This adds settings to the config template. They can be ignored if not applicable.